### PR TITLE
Update dj_rest_auth serializers for deprecation warnings

### DIFF
--- a/openwisp_radius/tests/test_api/test_api.py
+++ b/openwisp_radius/tests/test_api/test_api.py
@@ -486,7 +486,13 @@ class TestApi(AcctMixin, ApiTokenMixin, BaseTestCase):
             self.assertEqual(User.objects.count(), 2)
 
     @override_settings(
-        ACCOUNT_EMAIL_VERIFICATION="mandatory", ACCOUNT_EMAIL_REQUIRED=True
+        ACCOUNT_EMAIL_VERIFICATION="mandatory",
+        ACCOUNT_SIGNUP_FIELDS={
+            "username": {"required": True},
+            "email": {"required": True},
+            "password1": {"required": True},
+            "password2": {"required": True},
+        },
     )
     def test_email_verification_sent(self):
         self.assertEqual(User.objects.count(), 0)

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "passlib~=1.7.1",
         "djangorestframework-link-header-pagination~=0.1.1",
         "weasyprint>=65,<67",
-        "dj-rest-auth>=6.0,<7.1",
+        "dj-rest-auth>=7.1,<8",
         "django-sendsms~=0.5.0",
         "jsonfield~=3.1.0",
         "django-private-storage~=3.1.0",

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -293,6 +293,13 @@ REST_AUTH = {
 
 ACCOUNT_EMAIL_CONFIRMATION_ANONYMOUS_REDIRECT_URL = "email_confirmation_success"
 ACCOUNT_EMAIL_CONFIRMATION_AUTHENTICATED_REDIRECT_URL = "email_confirmation_success"
+# Align with allauth deprecations: configure required signup fields explicitly
+ACCOUNT_SIGNUP_FIELDS = {
+    "username": {"required": True},
+    "email": {"required": True},
+    "password1": {"required": True},
+    "password2": {"required": True},
+}
 
 # OPENWISP_RADIUS_PASSWORD_RESET_URLS = {
 #     # use the uuid because the slug can change


### PR DESCRIPTION
## Checklist

- [ ] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes the bug: "Deprecation warnings from dj_rest_auth in logs".

Please [open a new issue](https://github.com/openwisp/openwisp-radius/issues/new/choose) if there isn't an existing issue yet.

## Description of Changes

This PR addresses deprecation warnings originating from `dj-rest-auth` related to `django-allauth` settings.

The warnings occurred because `dj-rest-auth` was referencing deprecated `django-allauth` settings like `ACCOUNT_EMAIL_REQUIRED` and `ACCOUNT_USERNAME_REQUIRED`. To resolve this:

1.  `dj-rest-auth` dependency has been upgraded to `>=7.1,<8`, which uses the new `ACCOUNT_SIGNUP_FIELDS` API.
2.  Project settings (`tests/openwisp2/settings.py`) have been updated to explicitly define `ACCOUNT_SIGNUP_FIELDS`, replacing any implicit or deprecated `ACCOUNT_*_REQUIRED` settings.
3.  Relevant test cases (`openwisp_radius/tests/test_api/test_api.py`) using `override_settings` have been updated to reflect the new `ACCOUNT_SIGNUP_FIELDS` structure.

These changes eliminate the deprecation warnings by aligning with the latest `django-allauth` configuration practices.

## Screenshot

No screenshot needed for this change.

---
<a href="https://cursor.com/background-agent?bcId=bc-fff59ae7-3cc0-403c-8a61-bd324546ca6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fff59ae7-3cc0-403c-8a61-bd324546ca6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

